### PR TITLE
Fix some issues when using react-document-events with hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "mocha": "^5.0.0",
     "pre-commit": "^1.2.2",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.2.0",
+    "shallowequal": "1.1.0"
   },
   "peerDependencies": {
     "react": ">0.14",


### PR DESCRIPTION
Fix some major issues around callbacks. With new React hooks, it's more difficult to make functions never update. Previously, the first callbacks passed into react-document-events would be the ones bound - any future callbacks passed in would be ignored. Fix this issue and add some tests.